### PR TITLE
Update oss-banner.st

### DIFF
--- a/theme/src/main/assets/oss-banner.st
+++ b/theme/src/main/assets/oss-banner.st
@@ -6,8 +6,8 @@
 			</a>
 		</div>
 		<div class="nav">
-			<a class="banner-btn oss-track-link-label" data-category="OSS Lightbend Banner Clicks" data-label="Enhance your Cloudstate app with Lightbend [Button] - Cloudstate Banner" href="https://www.lightbend.com/cloudstate-by-lightbend?r=oss-banner-cloudstate" target="_blank">
-				<span>Enhance your Cloudstate app with</span>
+			<a class="banner-btn oss-track-link-label" data-category="OSS Lightbend Banner Clicks" data-label="Enhance your apps with Lightbend [Button] - Cloudstate Banner" href="https://www.lightbend.com/lightbend-subscription?r=oss-banner-cloudstate" target="_blank">
+				<span>Enhance your apps with</span>
 				<img class="lightbend-logo" src="$page.base$images/banner-logos/lightbend-reverse.svg" alt="Lightbend" title="Lightbend">
 			</a>
 			<div class="drop-down">
@@ -37,8 +37,8 @@
 						</a>
 						<div class="cloudstate current">
 							<img class="cloudstate-full-color-logo" src="$page.base$images/banner-logos/cloudstate-full-color.svg" alt="Cloudstate by Lightbend" title="Cloudstate by Lightbend">
-							<span>From the creators of <strong>Cloudstate</strong>, get developer assistance and expert support from Lightbend.</span>
-							<a class="oss-track-link-label" data-category="OSS Lightbend Banner Clicks" data-label="Learn More [Button] - Cloudstate Banner" href="https://www.lightbend.com/cloudstate-by-lightbend?r=oss-banner-cloudstate" target="_blank">Learn More</a>
+							<span>Get developer assistance and expert support from Lightbend.</span>
+							<a class="oss-track-link-label" data-category="OSS Lightbend Banner Clicks" data-label="Learn More [Button] - Cloudstate Banner" href="https://www.lightbend.com/lightbend-subscription?r=oss-banner-cloudstate" target="_blank">Learn More</a>
 						</div>
 					</div>
 					<div class="title">The Lightbend Family</div>


### PR DESCRIPTION
The OSS banners have been updated to include new links and simplified text.

As the /cloudstate-by-lightbend page has been replaced by /akka-serverless on Lightbend.com and we want to avoid confusion between the different versions, we've updated the language in the banners to be more generic and point to subscription page.

Could someone be kind enough to review and deploy.